### PR TITLE
Add exercise four to README

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -14,6 +14,7 @@
 | 01  | [**🎁 ¡Primer regalo repetido!**](https://adventjs.dev/es/challenges/2024/1) |     🟢     | [**codigo**](https://github.com/jeancdevx/adventjs-2024/blob/master/ejercicio1/index.js) | ⭐⭐⭐⭐⭐ |
 | 02  |    [**🖼️ Enmarcando nombres**](https://adventjs.dev/es/challenges/2024/2)    |     🟢     | [**codigo**](https://github.com/jeancdevx/adventjs-2024/blob/master/ejercicio2/index.js) | ⭐⭐⭐⭐⭐ |
 | 03  | [**🏗️ Organizando el inventario**](https://adventjs.dev/es/challenges/2024/3) |     🟢     | [**codigo**](https://github.com/jeancdevx/adventjs-2024/blob/master/ejercicio3/index.js) | ⭐⭐⭐⭐ |
+| 04  | [**🎄 Creando un árbol de Navidad**](https://adventjs.dev/es/challenges/2024/4) |     🟢     | [**codigo**](https://github.com/jeancdevx/adventjs-2024/blob/master/ejercicio4/index.js) | ⭐⭐⭐⭐⭐ |
 
 ## 📝 Clonar
 


### PR DESCRIPTION
Fixes #5

Add entry for exercise four in the `README.MD`.

* Include exercise four in the table of challenges.
* Add a link to `ejercicio4/index.js` for exercise four.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jeancdevx/adventjs-2024/pull/7?shareId=b75b1288-c4c5-41cd-964c-c9f354b126e1).